### PR TITLE
Update gd_mf_weights.cc right namespace

### DIFF
--- a/library/gd_mf_weights.cc
+++ b/library/gd_mf_weights.cc
@@ -94,11 +94,11 @@ int main(int argc, char *argv[])
     // write out features for right namespace
     features& right = ec->feature_space[right_ns];
     for (size_t i = 0; i < right.size(); ++i)
-    { right_linear << right.space_names[i].get()->second << '\t' << weights[left.indicies[i]];
+    { right_linear << right.space_names[i].get()->second << '\t' << weights[right.indicies[i]];
 
       right_quadratic << right.space_names[i].get()->second;
       for (size_t k = 1; k <= rank; k++)
-        right_quadratic << '\t' << weights[(left.indicies[i] + k + rank)];
+        right_quadratic << '\t' << weights[(right.indicies[i] + k)];
     }
     right_linear << endl;
     right_quadratic << endl;


### PR DESCRIPTION
Use right indices to write out features for the right namespace, correcting bug found in https://github.com/VowpalWabbit/vowpal_wabbit/issues/1871